### PR TITLE
Fix utterances selector

### DIFF
--- a/sphinx_comments/__init__.py
+++ b/sphinx_comments/__init__.py
@@ -77,8 +77,8 @@ def activate_comments(app, config):
             script.setAttribute("label", "{label}");
             script.setAttribute("crossorigin", "{crossorigin}");
 
-            sections = document.querySelectorAll("div.section");
-            if (sections !== null) {{
+            sections = document.querySelectorAll("section");
+            if (sections !== null && sections.length > 0) {{
                 section = sections[sections.length-1];
                 section.appendChild(script);
             }}


### PR DESCRIPTION
The selector to add utterances was invalid: section tags are not div.

![image](https://user-images.githubusercontent.com/49362475/180643625-7d8067f6-4929-40da-856f-7a871281b300.png)
