### PR TITLE
[FIX] Support section elements as well as div.section

### DIFF
--- a/sphinx_comments/__init__.py
+++ b/sphinx_comments/__init__.py
@@ -77,8 +77,8 @@ def activate_comments(app, config):
             script.setAttribute("label", "{label}");
             script.setAttribute("crossorigin", "{crossorigin}");
 
-            sections = document.querySelectorAll("div.section");
-            if (sections !== null) {{
+            sections = document.querySelectorAll("div.section,section");
+            if (sections !== null && sections.length > 0) {{
                 section = sections[sections.length-1];
                 section.appendChild(script);
             }}

--- a/tests/test_comments/utterances.html
+++ b/tests/test_comments/utterances.html
@@ -23,8 +23,8 @@ var addUtterances = () => {
     script.setAttribute("label", "💬 comment");
     script.setAttribute("crossorigin", "anonymous");
 
-    sections = document.querySelectorAll("div.section");
-    if (sections !== null) {
+    sections = document.querySelectorAll("div.section,section");
+    if (sections !== null && sections.length > 0) {
         section = sections[sections.length-1];
         section.appendChild(script);
     }


### PR DESCRIPTION
Investigating https://github.com/executablebooks/jupyter-book/issues/1762#issuecomment-1532896199 it seems that this module needs to be updated to support the use of `<section>` elements (which have superseded `<div class="section">` elements).

This PR updates `sphinx-comments` to support both ways of working. I also noticed that (on Chrome at least) `querySelectorAll` returns `[]` when there are not matches, not `null`, so I've modified the script to cope there and exit cleanly rather than throw an error.

(Sorry, didn't see https://github.com/executablebooks/.github/blob/d375020a952a579cca1c1e642b248a36da606b8b/CONTRIBUTING.md#commit-messages until opening this PR so the commit message is not properly formatted.)